### PR TITLE
Enable easy Heroku deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: python app.py

--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
 """This is your typical app, demonstrating usage."""
 
+import os
+
 from flask_jsondash.charts_builder import charts
 
 from flask import (
@@ -50,4 +52,5 @@ def index():
 
 
 if __name__ == '__main__':
-    app.run(debug=True, port=5002)
+    PORT = int(os.getenv('PORT', 5002))
+    app.run(debug=True, port=PORT)


### PR DESCRIPTION
This PR enables easy deployment of `app.py` to Heroku (and Heroku-like environments) by:

1. adding a Procfile indicating how to run the app
2. respecting the `$PORT` environment variable (falling back to port `5002` when not available)