### PR TITLE
new: [Chart options] POST or GET request with custom headers

### DIFF
--- a/flask_jsondash/static/js/app.js
+++ b/flask_jsondash/static/js/app.js
@@ -69,7 +69,7 @@ var jsondash = function() {
             return self.get(el.data().guid);
         };
         /**
-         * [getAllMatchingProp Get widget guids matching a givne propname and val]
+         * [getAllMatchingProp Get widget guids matching a given propname and val]
          */
         self.getAllMatchingProp = function(propname, val) {
             var matches = [];
@@ -99,12 +99,24 @@ var jsondash = function() {
             });
             return props;
         };
+        self.getAllOfPropUnlessPropEmpty = function(propname, propcheck) {
+            var props = [];
+            $.each(self.all(), function(i, widg){
+                if(widg.config[propcheck] !== undefined && widg.config[propcheck] !== null && widg.config[propcheck] !== "") {
+                    props.push(widg.config[propname]);
+                }
+            });
+            return props;
+        };
         /**
          * [loadAll Load all widgets at once in succession]
          */
         self.loadAll = function() {
             // Don't run this on certain types that are not cacheable (e.g. binary, html)
             var config_urls = self.getAllOfPropUnless('dataSource', 'family', 'Basic');
+            var config_urls_with_custom_header = self.getAllOfPropUnlessPropEmpty('dataSource', 'customHeader');
+            // do not make a request for custom headers
+            config_urls = config_urls.filter(url => config_urls_with_custom_header.indexOf(url) === -1);
             var unique_urls = d3.set(config_urls).values();
             var cached = {};
             var proms = [];
@@ -509,7 +521,7 @@ var jsondash = function() {
         populateRowField(conf.row);
         // Update the modal fields with this widgets' value.
         $.each(conf, function(field, val){
-            if(field === 'override' || field === 'refresh') {
+            if(field === 'override' || field === 'refresh' || field === 'isPOST') {
                 WIDGET_FORM.find('[name="' + field + '"]').prop('checked', val);
             } else if(field === 'classes') {
                 WIDGET_FORM.find('[name="' + field + '"]').val(val.join(','));
@@ -603,6 +615,9 @@ var jsondash = function() {
             width: form.find('[name="width"]').val(),
             height: parseNum(form.find('[name="height"]').val(), 10),
             dataSource: form.find('[name="dataSource"]').val(),
+            customHeader: form.find('[name="customHeader"]').val(),
+            isPOST: form.find('[name="isPOST"]').is(':checked'),
+            postData: form.find('[name="postData"]').val(),
             override: form.find('[name="override"]').is(':checked'),
             order: parseNum(form.find('[name="order"]').val(), 10),
             refresh: form.find('[name="refresh"]').is(':checked'),

--- a/flask_jsondash/static/js/app.js
+++ b/flask_jsondash/static/js/app.js
@@ -399,10 +399,16 @@ var jsondash = function() {
 
     function previewAPIRoute(e) {
         e.preventDefault();
+        var request_type = WIDGET_FORM.find('[name="isPOST"]').is(':checked') ? 'POST' : 'GET';
+        var customHeader = WIDGET_FORM.find('[name="customHeader"]').val();
+        customHeader = jsondash.util.getDicoHeader(customHeader);
+        var postData = request_type == 'POST' ? WIDGET_FORM.find('[name="postData"]').val() : {};
         // Shows the response of the API field as a json payload, inline.
         $.ajax({
-            type: 'GET',
+            type: request_type,
             url: API_ROUTE_URL.val().trim(),
+            headers: customHeader,
+            data: postData,
             success: function(data) {
                 API_PREVIEW.html(prettyCode(data));
                 API_PREVIEW.trigger(EVENTS.preview_api, [{status: data, error: false}]);

--- a/flask_jsondash/static/js/handlers.js
+++ b/flask_jsondash/static/js/handlers.js
@@ -54,24 +54,20 @@ jsondash.getJSON = function(container, config, callback) {
     }
 
     // perfom the request
+    var callbackFun = function(error, data){
+        jsondash.handleRes(error, data, container);
+        if(error || !data) {
+            return;
+        }
+        callback(error, config.key && data.multicharts[config.key] ? data.multicharts[config.key] : data);
+    }
+
     if (ispost) {
         var postedData = this.postDataFromString(config);
         var postedData = config.postData;
-        request.send("POST", postedData, function(error, data){
-            jsondash.handleRes(error, data, container);
-            if(error || !data) {
-                return;
-            }
-            callback(error, config.key && data.multicharts[config.key] ? data.multicharts[config.key] : data);
-        });
+        request.send("POST", postedData, callbackFun);
     } else {
-        request.get(function(error, data){
-            jsondash.handleRes(error, data, container);
-            if(error || !data) {
-                return;
-            }
-            callback(error, config.key && data.multicharts[config.key] ? data.multicharts[config.key] : data);
-        });
+        request.get(callbackFun);
     }
 };
 

--- a/flask_jsondash/static/js/handlers.js
+++ b/flask_jsondash/static/js/handlers.js
@@ -22,17 +22,6 @@ jsondash.handleRes = function(error, data, container) {
     }
 };
 
-jsondash.addAdditionalHeader = function(config, request) {
-    var customHeader = config.customHeader;
-    var headersList = customHeader.split('\n');
-    headersList.forEach(function(line) {
-        var temp = line.split(':');
-        var h = temp[0].replace(' ', '');
-        var v = temp[1].replace(' ', '')
-        request.header(h, v);
-    });
-};
-
 jsondash.postDataFromString = function(config) {
     var postData = config.postData;
     var data = JSON.parse(postData);
@@ -53,8 +42,16 @@ jsondash.getJSON = function(container, config, callback) {
 
     var request = d3.json(url);
 
+    // get additional headers
+    var customHeaderText = config.customHeader;
+    var headers = this.util.getDicoHeader(customHeaderText);
     // add the additional headers to the request
-    this.addAdditionalHeader(config, request);
+    for (var h in headers) {
+        if (headers.hasOwnProperty(h)) {
+            var v = headers[h];
+            request.header(h, v);
+        }
+    }
 
     // perfom the request
     if (ispost) {

--- a/flask_jsondash/static/js/utils.js
+++ b/flask_jsondash/static/js/utils.js
@@ -141,6 +141,18 @@ jsondash.util.isOverride = function(config) {
     return config.override && config.override === true;
 };
 
+jsondash.util.getDicoHeader = function(customHeaderText) {
+    dicoHeader = {};
+    var headersList = customHeaderText.split('\n');
+    headersList.forEach(function(line) {
+        var temp = line.split(':');
+        var h = temp[0].replace(' ', '');
+        var v = temp[1].replace(' ', '')
+        dicoHeader[h] = v;
+    });
+    return dicoHeader;
+};
+
 // Credit: http://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
 jsondash.util.s4 = function() {
     return Math.floor((1 + Math.random()) * 0x10000)

--- a/flask_jsondash/templates/partials/dashboard-edit-modal.html
+++ b/flask_jsondash/templates/partials/dashboard-edit-modal.html
@@ -59,6 +59,26 @@
                             Data Source <small class="text-danger">*</small>
                             <small>API, json, webpage, template, etc...</em></small>
                             <input class="form-control" type="text" name="dataSource" value="http://" placeholder="e.g. localhost:5000/my/endpoint" required>
+                            <div style="margin-left: 15px;">
+                                <a style="display: block;" class="collapsed" data-toggle="collapse" data-target="#collapsibleAdditionalHeader" aria-expanded="false" placeholder="">
+                                    Add custom header
+                                    <span class="fa fa-caret-down"></span>
+                                </a>
+                                <textarea id="collapsibleAdditionalHeader" name="customHeader" class="collapse form-control" style="width: 100%;" rows="3"></textarea>
+                            </div>
+                            <div style="margin-left: 15px;">
+                                <label>
+                                    <input type="checkbox" name="isPOST">
+                                    POST request?
+                                </label>
+                                <div style="margin-left: 15px;">
+                                    <a style="display: block;" class="collapsed" data-toggle="collapse" data-target="#collapsiblePOSTBody" aria-expanded="false" placeholder="">
+                                        Add POST body
+                                        <span class="fa fa-caret-down"></span>
+                                    </a>
+                                    <textarea id="collapsiblePOSTBody" name="postData" class="collapse form-control" style="width: 100%;" rows="3"></textarea>
+                                </div>
+                            </div>
                         </label>
                     </fieldset>
                 </div>


### PR DESCRIPTION
Hello,

As some API endpoints require to have specific headers like ``Authorization`` or use request headers to select their response format (CSV, JSON, ...), The following features has been implemented:
- Added possibility to choose between ``POST`` and ``GET`` request type
- Added possibility to set custom headers
- Added possibility to add a ``POST`` body (``POST`` request only)
- Support of the API preview

If you have comments or suggestions about the code, feel free to let me know.

Screenshot result:

![image](https://user-images.githubusercontent.com/6977223/46804320-9bd95200-cd62-11e8-8bba-72c010dd9f8d.png)
