### PR TITLE
Remove static url configuration that improperly sets url path to a fi…

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -1,0 +1,48 @@
+# https://prospector.landscape.io/en/master/profiles.html
+strictness: veryhigh
+test-warnings: true
+doc-warnings: true
+ignore-paths:
+  - build
+  - htmlcov
+  - tests
+  - .pytest_cache
+  - .git
+  - env
+  - venv
+  - docs
+  - /**/__init__.py
+ignore-patterns:
+  - (^|/)skip(this)?(/|$)
+# ALL runners below:
+pep8:
+  full: true
+  disable:
+    - W602
+    - W603
+pyflakes:
+  run: true
+  disable:
+    - F821
+pep257:
+    # We use google docstrings in this package.
+    - D203
+pylint:
+  run: true
+  options:
+    max-line-length: 80
+dodgy:
+  run: true
+frosted:
+  run: true
+pyroma:
+  run: true
+mccabe:
+  run: true
+  max-line-length: 80
+  max-complexity: 10
+  disable:
+    - D400
+    - D205
+    # Should be removed in favor of max-complexity.
+    - MC0001

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,9 @@ notifications:
     recipients:
       - dxdstudio@gmail.com
     on_failure: always
-    on_success: always
 install:
-    - pip install -U coveralls
-    - pip install -U tox
-    - pip install -U pytest
-    - pip install -U pyquery
-    - python setup.py install
+    - pip install --upgrade pip setuptools tox
+    - pip install .
 script: tox -e $TOXENV
 after_success:
   coveralls

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+## Contributing
+
+If you'd like to work on the project, a good place to start is using the example app to develop against. To do this easily, you'll want to setup a virtual environment and setup the package locally, using the `develop` mode of `setuptools`. The below should get you started:
+
+```shell
+git clone github.com/christabor/flask_jsondash.git
+cd flask_jsondash
+virtualenv env
+source env/bin/activate
+git checkout -b YOUR_NEW_BRANCH
+python setup.py develop
+cd example_app
+python app.py
+```
+
+And voila! You can now edit the folder directly, and still use it as a normal pip package without having to reinstall every time you change something.
+
+## Tests
+
+To run all tests for python 2.7 and 3.x, with coverage, just run `tox` (assuming tox is installed.)
+
+### Python
+
+You can run these tests using pytest (`pip install -U pytest`) and then in the existing virtualenv, run `pytest tests`.
+
+If you are having issues with this approach, an alternative would be to install pytest within the projects' virtualenv (assuming you've created one), and then running it like so: `python -m pytest tests`.
+
+#### Test coverage
+
+To find coverage information (assuming `pytest-cov` is installed), you can run: `pytest tests -s --cov=flask_jsondash`.
+
+### Javascript
+
+JS tests are run using the node library Jasmine. To install and run it, you'll need nodejs installed, then the package: `npm install -g jasmine`. You can then `cd` into the `tests_js` folder and run the provided python script `python runner.py`

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ fixtures:
 fixturize:
 	mkdir -p fixtures/
 	python -m flask_jsondash.model_factories --dump fixtures
+lint:
+	prospector --zero-exit --die-on-tool-error --profile-path=.prospector.yml flask_jsondash
 pypi:
 	python setup.py sdist upload -r pypi
 sort:
@@ -44,5 +46,6 @@ help:
 	@echo "dropall ..... Delete all dashboards"
 	@echo "fixtures .... Load all example dashboards"
 	@echo "fixturize ... Convert existing database records to fixtures"
+	@echo "lint ........ Run all code linting"
 	@echo "tests ....... Run all tests"
 	@echo "testdata .... Generate some test data"

--- a/README.md
+++ b/README.md
@@ -511,37 +511,6 @@ This is usually only an issue with datatables, particularly when selecting the n
 
 You can also use the override option supported by this chart, and specify the number of results per page, and the number of entries that can be shown. See the [datatables schema docs](docs/schemas.md#datatables) for more.
 
-## Contributing/Development
+## Contributing
 
-If you'd like to work on the project, a good place to start is using the example app to develop against. To do this easily, you'll want to setup a virtual environment and setup the package locally, using the `develop` mode of `setuptools`. The below should get you started:
-
-```shell
-git clone github.com/christabor/flask_jsondash.git
-cd flask_jsondash
-virtualenv env
-source env/bin/activate
-git checkout -b YOUR_NEW_BRANCH
-python setup.py develop
-cd example_app
-python app.py
-```
-
-And voila! You can now edit the folder directly, and still use it as a normal pip package without having to reinstall every time you change something.
-
-## Tests
-
-To run all tests for python 2.7 and 3.x, with coverage, just run `tox` (assuming tox is installed.)
-
-### Python
-
-You can run these tests using pytest (`pip install -U pytest`) and then in the existing virtualenv, run `pytest tests`.
-
-If you are having issues with this approach, an alternative would be to install pytest within the projects' virtualenv (assuming you've created one), and then running it like so: `python -m pytest tests`.
-
-#### Test coverage
-
-To find coverage information (assuming `pytest-cov` is installed), you can run: `pytest tests -s --cov=flask_jsondash`.
-
-### Javascript
-
-JS tests are run using the node library Jasmine. To install and run it, you'll need nodejs installed, then the package: `npm install -g jasmine`. You can then `cd` into the `tests_js` folder and run the provided python script `python runner.py`
+See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/flask_jsondash/charts_builder.py
+++ b/flask_jsondash/charts_builder.py
@@ -6,7 +6,7 @@ flask_jsondash.charts_builder
 
 The chart blueprint that houses all functionality.
 
-:copyright: (c) 2016 by Chris Tabor.
+:copyright: (c) 2019 by Chris Tabor.
 :license: MIT, see LICENSE for more details.
 """
 

--- a/flask_jsondash/charts_builder.py
+++ b/flask_jsondash/charts_builder.py
@@ -44,7 +44,6 @@ charts = Blueprint(
     'jsondash',
     __name__,
     template_folder=TEMPLATE_DIR,
-    static_url_path=STATIC_DIR,
     static_folder=STATIC_DIR,
 )
 

--- a/flask_jsondash/data_utils/filetree.py
+++ b/flask_jsondash/data_utils/filetree.py
@@ -10,13 +10,14 @@ from the list of files and directories on a given path.
 
 Re-purposed from: github.com/christabor/MoAL/blob/master/MOAL/get_file_tree.py
 
-:copyright: (c) 2016 by Chris Tabor.
+:copyright: (c) 2019 by Chris Tabor.
 :license: MIT, see LICENSE for more details.
 """
 
 import errno
 import json
 import os
+
 from pprint import pprint
 
 import click

--- a/flask_jsondash/data_utils/filetree_digraph.py
+++ b/flask_jsondash/data_utils/filetree_digraph.py
@@ -8,7 +8,7 @@ flask_jsondash.data_utils.filetree_digraph
 A utility for getting digraph friendly data structures
 from the list of files and directories on a given path.
 
-:copyright: (c) 2016 by Chris Tabor.
+:copyright: (c) 2019 by Chris Tabor.
 :license: MIT, see LICENSE for more details.
 """
 
@@ -65,19 +65,17 @@ def make_dotfile(path):
 @click.command()
 @click.option('--dot', '-d',
               default=None,
+              type=click.File('wb'),
               help='Output specified file as a dotfile.')
 @click.option('--path', '-p',
               default='.',
+              type=click.Path(exists=True),
               help='The starting path')
 def get_dotfile_tree(path, dot):
     """CLI wrapper for existing functions."""
     res = make_dotfile(path)
-    if path == '.':
-        raise ValueError('Running in the same directory when no'
-                         ' folders are present does not make sense.')
     if dot is not None:
-        with open(dot, 'w') as dotfile:
-            dotfile.write(res)
+        dot.write(res.encode('utf-8'))
         return
     else:
         print(res)

--- a/flask_jsondash/data_utils/wordcloud.py
+++ b/flask_jsondash/data_utils/wordcloud.py
@@ -7,15 +7,17 @@ flask_jsondash.data_utils.wordcloud
 
 Utilities for working with wordcloud formatted data.
 
-:copyright: (c) 2016 by Chris Tabor.
+:copyright: (c) 2019 by Chris Tabor.
 :license: MIT, see LICENSE for more details.
 """
 
-from collections import Counter
-from string import punctuation
 import re
 
+from collections import Counter
+from string import punctuation
+
 import requests
+
 from pyquery import PyQuery as Pq
 
 # Py2/3 compat.

--- a/flask_jsondash/db.py
+++ b/flask_jsondash/db.py
@@ -6,11 +6,12 @@ flask_jsondash.db
 
 A translation adapter for transparent operations between storage types.
 
-:copyright: (c) 2016 by Chris Tabor.
+:copyright: (c) 2019 by Chris Tabor.
 :license: MIT, see LICENSE for more details.
 """
 
 import json
+
 from datetime import datetime as dt
 
 from pymongo import MongoClient

--- a/flask_jsondash/model_factories.py
+++ b/flask_jsondash/model_factories.py
@@ -6,17 +6,19 @@ flask_jsondash.model_factories
 
 Data generation utilities for all charts and dashboards.
 
-:copyright: (c) 2016 by Chris Tabor.
+:copyright: (c) 2019 by Chris Tabor.
 :license: MIT, see LICENSE for more details.
 """
 
-import os
 import json
+import os
+
 from datetime import datetime as dt
 from random import choice, randrange
 from uuid import uuid1
 
 import click
+
 from werkzeug.datastructures import ImmutableMultiDict
 
 from flask_jsondash import db, settings

--- a/flask_jsondash/mongo_adapter.py
+++ b/flask_jsondash/mongo_adapter.py
@@ -6,7 +6,7 @@ flask_jsondash.mongo_adapter
 
 Adapters for various storage engines.
 
-:copyright: (c) 2016 by Chris Tabor.
+:copyright: (c) 2019 by Chris Tabor.
 :license: MIT, see LICENSE for more details.
 """
 

--- a/flask_jsondash/schema.py
+++ b/flask_jsondash/schema.py
@@ -6,7 +6,7 @@ flask_jsondash.schema
 
 The core schema definition and validation rules.
 
-:copyright: (c) 2016 by Chris Tabor.
+:copyright: (c) 2019 by Chris Tabor.
 :license: MIT, see LICENSE for more details.
 """
 
@@ -25,7 +25,7 @@ def get_chart_types():
     """Get all available chart 'type' names from core config.
 
     Returns:
-        types (list): A list of all possible chart types, under all families.
+        list: A list of all possible chart types, under all families.
     """
     types = []
     charts = [chart['charts'] for chart in CHARTS_CONFIG.values()]
@@ -229,7 +229,14 @@ DASHBOARD_SCHEMA = {
 
 
 def validate(conf):
-    """Validate a json conf."""
+    """Validate a json conf.
+
+    Args:
+        conf (dict): The schema configuration.
+
+    Returns:
+        list: A list of schema errors, or None.
+    """
     v = cerberus.Validator(DASHBOARD_SCHEMA, allow_unknown=True)
     valid = v.validate(conf)
     if not valid:
@@ -245,9 +252,9 @@ def is_consecutive_rows(lst):
     Returns:
         True/False: If the list contains consecutive integers.
 
-    Originally taken from and modified:
-        http://stackoverflow.com/
-            questions/40091617/test-for-consecutive-numbers-in-list
+    ..note: Originally taken from and modified:
+        stackoverflow.com/questions/40091617/
+            test-for-consecutive-numbers-in-list
     """
     assert 0 not in lst, '0th index is invalid!'
     lst = list(set(lst))
@@ -312,7 +319,7 @@ def validate_raw_json(jsonstr, **overrides):
         InvalidSchemaError: If there are any issues with the schema
 
     Returns:
-        data (dict): The parsed configuration data
+        dict: The parsed configuration data
     """
     data = json.loads(jsonstr)
     data.update(**overrides)

--- a/flask_jsondash/settings.py
+++ b/flask_jsondash/settings.py
@@ -6,7 +6,7 @@ flask_jsondash.settings
 
 App/blueprint wide settings.
 
-:copyright: (c) 2016 by Chris Tabor.
+:copyright: (c) 2019 by Chris Tabor.
 :license: MIT, see LICENSE for more details.
 """
 

--- a/flask_jsondash/utils.py
+++ b/flask_jsondash/utils.py
@@ -6,7 +6,7 @@ flask_jsondash.utils
 
 General utils for handling data within the blueprint.
 
-:copyright: (c) 2016 by Chris Tabor.
+:copyright: (c) 2019 by Chris Tabor.
 :license: MIT, see LICENSE for more details.
 """
 

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,6 @@ from setuptools import setup
 
 SRCDIR = '.'
 folder = os.path.abspath(os.path.dirname(__file__))
-test_requirements = [
-    'pytest==4.0.2',
-    'pytest-cov==2.6.0',
-    'pyquery==1.4.0',
-    'requests_mock',
-]
 extras_require = {
     'wordcloud-utils': [
         'requests',
@@ -42,7 +36,7 @@ def readme():
 
 setup(
     name='flask_jsondash',
-    version='6.3.3',
+    version='6.3.4',
     description=('Easily configurable, chart dashboards from any '
                  'arbitrary API endpoint. JSON config only. Ready to go.'),
     long_description=readme(),
@@ -56,11 +50,12 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     extras_require=extras_require,
-    tests_require=test_requirements,
     install_requires=requirements,
     package_dir={'flask_jsondash': 'flask_jsondash'},
     packages=['flask_jsondash'],

--- a/tests/test_data_utils_filetree.py
+++ b/tests/test_data_utils_filetree.py
@@ -33,14 +33,6 @@ def test_path_hierarchy_invalid_path_empty_path(tmpdir):
         filetree.path_hierarchy('')
 
 
-def test_get_tree_invalid_path(tmpdir):
-    runner = CliRunner()
-    result = runner.invoke(filetree.get_tree, ['-p', '/{}'.format(uuid1())])
-    assert result.exit_code == -1
-    assert isinstance(result.exception, OSError)
-    assert 'No such file or directory' in str(result.exception)
-
-
 def test_get_tree_valid_path(tmpdir):
     uid = str(uuid1())
     tmp = tmpdir.mkdir(uid)

--- a/tests/test_data_utils_filetree_digraph.py
+++ b/tests/test_data_utils_filetree_digraph.py
@@ -43,14 +43,6 @@ def test_make_dotfile_invalid_path_none():
         filetree_digraph.make_dotfile(None)
 
 
-def test_get_dotfile_tree_invalid_path(tmpdir):
-    runner = CliRunner()
-    result = runner.invoke(filetree_digraph.get_dotfile_tree, ['-p', '.'])
-    assert result.exit_code == -1
-    assert isinstance(result.exception, ValueError)
-    assert 'Running in the same directory when no' in str(result.exception)
-
-
 def test_get_dotfile_tree_valid_path(tmpdir):
     uid = str(uuid1())
     tmp = tmpdir.mkdir(uid)
@@ -67,10 +59,10 @@ def test_get_dotfile_tree_valid_path_dotfile(tmpdir):
     tmp = tmpdir.mkdir(uid)
     tmpfile = tmp.join('foo.dot')
     tmpfilepath = str(tmpfile.realpath())
-    tmppath = str(tmp.realpath())
     runner = CliRunner()
     result = runner.invoke(
-        filetree_digraph.get_dotfile_tree, ['-p', tmppath, '-d', tmpfilepath])
+        filetree_digraph.get_dotfile_tree, ['-p', tmp.strpath, '-d',
+                                            tmpfilepath])
     assert result.exit_code == 0
     with open(tmpfilepath, 'r') as res:
-        assert 'digraph' in str(res.read())
+        assert 'digraph' in res.read()

--- a/tests/test_data_utils_filetree_digraph.py
+++ b/tests/test_data_utils_filetree_digraph.py
@@ -8,18 +8,18 @@ from flask_jsondash.data_utils import filetree_digraph
 
 
 def test_make_dotfile(tmpdir):
-    uid = str(uuid1())
-    tmp = tmpdir.mkdir(uid)
+    tmp = tmpdir.mkdir('somedir')
     for i in range(4):
         tmp.join('{}.txt'.format(i)).write('{}'.format(i))
     data = filetree_digraph.make_dotfile(tmp.strpath)
     # Ensure wrapping lines are proper digraph format.
-    assert data.startswith('digraph {\n')
-    assert data.endswith('\n}\n')
-    lines = data.split('\n')
-    # Ensure each line has the right dotfile format.
-    for i, line in enumerate(lines[1:len(lines) - 2]):
-        assert line == '\t"{0}" -> "{1}.txt";'.format(uid, i)
+    res = data.split('\n')
+    assert res[0] == 'digraph {'
+    assert res[1] == '\t"somedir" -> "0.txt";'
+    assert res[2] == '\t"somedir" -> "1.txt";'
+    assert res[3] == '\t"somedir" -> "2.txt";'
+    assert res[4] == '\t"somedir" -> "3.txt";'
+    assert res[5] == '}'
 
 
 def test_make_dotfile_skip_empty(monkeypatch, tmpdir):

--- a/tox.ini
+++ b/tox.ini
@@ -8,13 +8,22 @@ deps=pytest
      pytest-cov
      pyquery
      requests_mock
-commands=pytest -s -v --cov-report term --cov=flask_jsondash tests
+commands=pytest -s --cov-report term --cov=flask_jsondash tests
+
+[testenv:py2.7]
+commands=
+    make lint
+    python2.7 -m pytest -s --cov-report term --cov=flask_jsondash tests
 
 [testenv:py3.5]
-commands=python3.5 -m pytest -s -v --cov-report term --cov=flask_jsondash tests
+commands=
+    make lint
+    python3.5 -m pytest -s --cov-report term --cov=flask_jsondash tests
 
 [testenv:py3.6]
-commands=python3.6 -m pytest -s -v --cov-report term --cov=flask_jsondash tests
+commands=
+    make lint
+    python3.6 -m pytest -s --cov-report term --cov=flask_jsondash tests
 
 [flake8]
 max-line-length=80

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist=py{27,35,36}
 
 [testenv]
 usedevelop=True
-deps=pytest
+deps=coveralls
+     pytest
      pytest-cov
      pyquery
      requests_mock


### PR DESCRIPTION
…le path, resulting in a 500 error in Windows. Closes #128.

Locally I'm able to confirm this works both during testing and in manual viewing of the page. I think this was originally set for the purpose  of making it installable not just as an app, but as an imported package. However, the docs for flask indicate that this is always relative to the application, and this is configured to use an absolute path anyway:

`STATIC_DIR = os.path.dirname(static.__file__)`

so, this should negate the need to manually set both.

<img width="1508" alt="screen shot 2019-02-28 at 9 55 36 pm" src="https://user-images.githubusercontent.com/410839/53619336-e2113f80-3ba3-11e9-8109-facff880e67b.png">
